### PR TITLE
overview header refresh fixed

### DIFF
--- a/modules/core/views/js/jquery.objectOverview.js.php
+++ b/modules/core/views/js/jquery.objectOverview.js.php
@@ -64,11 +64,8 @@
 
                 // On overview_header_refresh event reload overview header
                 $_this.on('overview_header_refresh', function() {
-                    return; // @todo - not supported in ForzaTheme
                     // Keep active item active
                     var active_item_id = $_this.find('ul>li.active a.submenu_item').attr('id');
-//                    var $res = $.get(settings.overview_header_refresh_url);
-//                    console.log($res);
                     $_this.find('.overview_header').load(settings.overview_header_refresh_url, function(){
                         $_this.find('#' + active_item_id).parents('li:first').addClass('active');
                     });

--- a/modules/core/views/overview_content_standard.php
+++ b/modules/core/views/overview_content_standard.php
@@ -6,9 +6,9 @@
 
 <div class="overview_container tab-container tab-sky tab-normal" id="<?= $overview_container_id;?>">
 
-<!--        <div class="overview_header">-->
+<div class="overview_header">
         <?= $header ?>
-<!--    </div>-->
+</div>
 <!-- overview_header -->
 
     <div class="view-data tab-content data overview_subcontent">

--- a/modules/core/views/overview_header_layout_standard.php
+++ b/modules/core/views/overview_header_layout_standard.php
@@ -1,7 +1,4 @@
 
 <?= $header; ?><?php // custom object overview header ?>
 
-
-<!-- <div class="view-nav overview_submenu"> -->
-    <?= $submenu; ?>
-<!-- </div> -->
+<?= $submenu; ?>

--- a/modules/form/classes/core/appform.php
+++ b/modules/form/classes/core/appform.php
@@ -639,6 +639,7 @@ class Core_AppForm {
             
             //nastavim vysledek akce
             $this->requested_action_result = self::ACTION_RESULT_FAILED;
+            $special_message = $e->getMessage();
         }
 
         if ($show_action_result)


### PR DESCRIPTION
This will allow us to use a generic functionality to refresh overview header sections when the form is saved:

![image](https://user-images.githubusercontent.com/1590760/118667813-9be03f00-b7f4-11eb-95e7-49696258f78d.png)
